### PR TITLE
fix: Main 브랜치가 Push되었을 때만 Github Actions 동작

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,8 +3,6 @@ name: Docker Image CI
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
   build-and-push:
@@ -14,7 +12,7 @@ jobs:
       packages: write
 
     steps:
-    - name: Build the Docker image
+    - name: Checkout code
       uses: actions/checkout@v4
 
     - name: Log in to GitHub Container Registry


### PR DESCRIPTION
### 업데이트
- Main 브랜치가 Push되었을 때만 Github Actions 동작